### PR TITLE
Appliance rescan issue

### DIFF
--- a/src/app/components/Appliance.js
+++ b/src/app/components/Appliance.js
@@ -38,13 +38,13 @@ class Appliance extends Component {
 
         //click on the checkbox if props selecteTypeCheckbox = true
         this.checkBoxClick = () => {
-            let selfID = this.props.appliance.id;
+            let applianceName = this.props.appliance.name;
             let {removeSelection, addSelection} = this.props;
             let isCheckbox = true;
             if (this.state.checked) {
-                removeSelection(selfID);
+                removeSelection(applianceName);
             } else {
-                addSelection(selfID, isCheckbox);
+                addSelection(applianceName, isCheckbox);
             }
 
             this.setState({
@@ -55,9 +55,9 @@ class Appliance extends Component {
         //click on the radio button if props selecteTypeCheckbox = false
         this.radioClick = () => {
             let {addSelection} = this.props;
-            let selfID = this.props.appliance.id;
+            let applianceName = this.props.appliance.name;
             let isCheckBox = false;
-            addSelection(selfID, isCheckBox);
+            addSelection(applianceName, isCheckBox);
         };
     }
 

--- a/src/app/components/SlideOutDialog.js
+++ b/src/app/components/SlideOutDialog.js
@@ -26,7 +26,7 @@ class SlideOutDialog extends Component {
             selected = isCheckBox ? selected : [];
             selected.push(selectionName);
             this.setState({
-                sselectedNames: selected
+                selectedNames: selected
             });
         };
 
@@ -42,7 +42,7 @@ class SlideOutDialog extends Component {
             let selected = this.state.selectedNames;
             let configured = this.props.configured;
             let unconfiguredAppliance = this.props.selectedAppliance;
-            let appliance = configured.find(appliance => appliance.id === selected[0]);
+            let appliance = configured.find(appliance => appliance.name === selected[0]);
             let link = appliance.link + "/?appliances=" + unconfiguredAppliance.name;
 
             ipcRndr.send("connect-to-appliance", link);

--- a/src/app/components/SlideOutDialog.js
+++ b/src/app/components/SlideOutDialog.js
@@ -12,7 +12,7 @@ class SlideOutDialog extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            selected_ids: []
+            selectedNames: []
         };
 
         this.toggle = () => {
@@ -21,28 +21,28 @@ class SlideOutDialog extends Component {
             });
         };
 
-        this.addSelection = (selectionId, isCheckBox) => {
-            let selected = this.state.selected_ids;
+        this.addSelection = (selectionName, isCheckBox) => {
+            let selected = this.state.selectedNames;
             selected = isCheckBox ? selected : [];
-            selected.push(selectionId);
+            selected.push(selectionName);
             this.setState({
-                selected_ids: selected
+                sselectedNames: selected
             });
         };
 
-        this.removeSelection = (selectionId) => {
-            let selected = this.state.selected_ids;
-            selected = selected.filter((id) => id !== selectionId);
+        this.removeSelection = (selectionName) => {
+            let selected = this.state.selectedNames;
+            selected = selected.filter((name) => name !== selectionName);
             this.setState({
-                selected_ids: selected
+                selectedNames: selected
             });
         };
 
         this.addClick = () => {
-            let selected = this.state.selected_ids;
+            let selected = this.state.selectedNames;
             let configured = this.props.configured;
             let unconfiguredAppliance = this.props.selectedAppliance;
-            let appliance = configured.filter(appliance => appliance.id === selected[0])[0];
+            let appliance = configured.find(appliance => appliance.id === selected[0]);
             let link = appliance.link + "/?appliances=" + unconfiguredAppliance.name;
 
             ipcRndr.send("connect-to-appliance", link);
@@ -52,9 +52,9 @@ class SlideOutDialog extends Component {
 
     render() {
         let {configured, selectedAppliance} = this.props;
-        let {selected_ids} = this.state;
+        let {selectedNames} = this.state;
 
-        let isAddBtnActive = selected_ids.length === 1;
+        let isAddBtnActive = selectedNames.length === 1;
 
         let selectedApplianceName = selectedAppliance ? selectedAppliance.name : "";
 
@@ -75,8 +75,8 @@ class SlideOutDialog extends Component {
                                 configured.map(appliance => {
                                     let active = false;
 
-                                    selected_ids.forEach((element) => {
-                                        if (element === appliance.id) {
+                                    selectedNames.forEach((element) => {
+                                        if (element === appliance.name) {
                                             active = true;
                                         }
                                     });
@@ -85,7 +85,7 @@ class SlideOutDialog extends Component {
                                         <Appliance addSelection={this.addSelection}
                                                    removeSelection={this.removeSelection}
                                                    itemClick={null}
-                                                   key={appliance.id}
+                                                   key={appliance.name}
                                                    appliance={appliance}
                                                    showSettingsMenu={false}
                                                    active={active}/>

--- a/src/app/containers/AppliancesPage.js
+++ b/src/app/containers/AppliancesPage.js
@@ -221,6 +221,14 @@ class AppliancesPage extends Component {
     }
 
     componentDidMount() {
+        this.getApplianceList();
+        
+        ipcRndr.on('update-appliance-list', (event, message) => {
+            this.getApplianceList();
+        });
+    }
+
+    getApplianceList() {
         //parse data from backend
         let appliances = JSON.parse(localStorage.getItem("message")).storages;
 

--- a/src/app/containers/AppliancesPage.js
+++ b/src/app/containers/AppliancesPage.js
@@ -255,6 +255,10 @@ class AppliancesPage extends Component {
         });
     }
 
+    componentWillUnmount() {
+        ipcRndr.removeAllListeners('update-appliance-list');
+    }
+
     getApplianceList() {
         //parse data from backend
         let appliances = JSON.parse(localStorage.getItem("message")).storages;

--- a/src/app/containers/AppliancesPage.js
+++ b/src/app/containers/AppliancesPage.js
@@ -222,8 +222,12 @@ class AppliancesPage extends Component {
 
     componentDidMount() {
         this.getApplianceList();
-        
+
         ipcRndr.on('update-appliance-list', (event, message) => {
+            if (message !== 'add') {
+                let unselectedAppliance = this.state.appliances.filter(appliance => appliance.name === message);
+                unselectedAppliance.forEach(appliance => this.removeSelection(appliance.id));
+            }
             this.getApplianceList();
         });
     }

--- a/src/app/containers/log/detectionLog.js
+++ b/src/app/containers/log/detectionLog.js
@@ -22,8 +22,10 @@ class DetectionLog extends React.Component {
     };
 
     refreshLogs() {
-        this.state.detLogs = JSON.parse(localStorage.getItem('logs'));
-        this.forceUpdate();
+        this.setState({
+            detLogs: JSON.parse(localStorage.getItem('logs')),
+            eventLogs: JSON.parse(localStorage.getItem('eventlogs'))
+        })
     }
 
     changeSubtabs(subtab) {
@@ -120,9 +122,14 @@ class DetectionLog extends React.Component {
     }
 
     componentDidMount() {
-        ipcRndr.on('update-appliance-list', (event, message, newApplianceName) => {
+        this.refreshLogs();
+        ipcRndr.on('update-appliance-list', (event, message, newApplianceName) => {  
             this.refreshLogs();
         });
+    }
+
+    componentWillUnmount() {
+        ipcRndr.removeAllListeners('update-appliance-list');
     }
 
     render() {

--- a/src/app/containers/log/detectionLog.js
+++ b/src/app/containers/log/detectionLog.js
@@ -16,12 +16,12 @@ class DetectionLog extends React.Component {
         this.changeSubtabs = this.changeSubtabs.bind(this);
         this.returnTabs = this.returnTabs.bind(this);
         this.eachLog = this.eachLog.bind(this);
-        this.refreshButton = this.refreshButton.bind(this);
+        this.refreshLogs = this.refreshLogs.bind(this);
         this.saveLogs = this.saveLogs.bind(this);
         this.clearLogs = this.clearLogs.bind(this);
     };
 
-    refreshButton() {
+    refreshLogs() {
         this.state.detLogs = JSON.parse(localStorage.getItem('logs'));
         this.forceUpdate();
     }
@@ -49,7 +49,7 @@ class DetectionLog extends React.Component {
         var logs = JSON.stringify(tmp, "", 4);
         localStorage.setItem('logs', logs);
         ipcRndr.send('clearDetectLog', "Clear logs");
-        this.refreshButton();
+        this.refreshLogs();
     }
 
     // Save detection logs
@@ -119,6 +119,12 @@ class DetectionLog extends React.Component {
         );
     }
 
+    componentDidMount() {
+        ipcRndr.on('update-appliance-list', (event, message, newApplianceName) => {
+            this.refreshLogs();
+        });
+    }
+
     render() {
         if (this.state.subtab == "detectionLog") {
             return (
@@ -146,7 +152,7 @@ class DetectionLog extends React.Component {
                                 {/*<div className="saveLogButton" onClick={this.clearLogs}>
                                     <font>{mainPage_lang.LOGS_buttonClear}</font>
                                 </div>*/}
-                                {/*<div id="buttonRenewLog" onClick={this.refreshButton}>
+                                {/*<div id="buttonRenewLog" onClick={this.refreshLogs}>
                                     <img id="refIcon" src="icon/refresh.svg" height="20"/>
                                 </div>*/}
                                 <table id="detectionLogTable">

--- a/src/demo/demo_data.json
+++ b/src/demo/demo_data.json
@@ -103,7 +103,7 @@
     },
     {
       "link": "http://192.168.2.58:8080",
-      "name": "FNM003456009762",
+      "name": "FNM003456009763",
       "state": "unconfigured",
       "model": "ProductName 1000X",
       "type": "HCI",
@@ -112,7 +112,7 @@
     },
     {
       "link": "http://192.168.2.58:8080",
-      "name": "FNM003456009762",
+      "name": "FNM003456009764",
       "state": "unconfigured",
       "type": "BM",
       "model": "ProductName 1000",
@@ -121,7 +121,7 @@
     },
     {
       "link": "http://192.168.2.58:8080",
-      "name": "FNM003456009762",
+      "name": "FNM003456009765",
       "state": "unconfigured",
       "type": "HCI",
       "model": "ProductName 1000X",

--- a/src/main.js
+++ b/src/main.js
@@ -116,6 +116,14 @@ function getModelByCode(code, type) {
     return productName + " " + productModel + typePostfix;
 }
 
+function splicingLogStorages(tmpLog, newElem) {
+    tmpLog.storages.splice(0, 0, addTypeInLogs(newElem));
+    console.log(`Discovered appliance:\n${jsonParseString(tmpLog.storages[0])}\n`);
+    if (tmpLog.storages.length > 1000) {
+        tmpLog.storages.splice(1000, tmpLog.storages.length - 1000);
+    }
+}
+
 // The event handler for the emergence of a new device in the network
 function appOnUp(service) {
     console.log('#######################################\nadding');
@@ -154,14 +162,14 @@ function appOnUp(service) {
         newElement.model = getModelByCode(serviceNames[4], newElement.type);
 
         //System state
-//  "Unconfigured", 0                 // system in factory state
-//  "Unconfigured_Faulted", 1       // Hardware is in faulted state
-//  "Configuring", 2                   // In the midst of being configured or unconfigured
-//  "Configured", 3                     // system is configured
-//  "Expanding", 4                       // System is adding a new appliance
-//  "Removing", 5                         // System is removing an appliance
-//  "Clustering_Failed", 6       // system in a bad state
-//  "Unknown", 99                          // unknown state
+        //  "Unconfigured", 0                 // system in factory state
+        //  "Unconfigured_Faulted", 1       // Hardware is in faulted state
+        //  "Configuring", 2                   // In the midst of being configured or unconfigured
+        //  "Configured", 3                     // system is configured
+        //  "Expanding", 4                       // System is adding a new appliance
+        //  "Removing", 5                         // System is removing an appliance
+        //  "Clustering_Failed", 6       // system in a bad state
+        //  "Unknown", 99                          // unknown state
 
         if (serviceNames[7] === '0' || serviceNames[7] === '1') {
             newElement.state = 'unconfigured';
@@ -184,11 +192,7 @@ function appOnUp(service) {
         if (tmp != null) {
             if (tmp.storages.length == 0) {
                 tmp.storages.push(newElement);
-                tmpLog.storages.splice(0, 0, addTypeInLogs(newElement));
-                console.log('Discovered appliance:\n' + jsonParseString(tmpLog.storages[0]) + '\n');
-                if (tmpLog.storages.length > 1000) {
-                    tmpLog.storages.splice(1000, tmpLog.storages.length - 1000);
-                }
+                splicingLogStorages(tmpLog, newElement);
             } else {
                 var isInserted = false;
                 for (var i = 0; i < tmp.storages.length; i++) {
@@ -198,31 +202,19 @@ function appOnUp(service) {
                     }
                     if (tmp.storages[i].name > newElement.name) {
                         tmp.storages.splice(i, 0, newElement);
-                        tmpLog.storages.splice(0, 0, addTypeInLogs(newElement));
-                        console.log('Discovered appliance:\n' + jsonParseString(tmpLog.storages[0]) + '\n');
-                        if (tmpLog.storages.length > 1000) {
-                            tmpLog.storages.splice(1000, tmpLog.storages.length - 1000);
-                        }
+                        splicingLogStorages(tmpLog, newElement);
                         isInserted = true;
                         break;
                     }
                 }
                 if (!isInserted) {
                     tmp.storages.push(newElement);
-                    tmpLog.storages.splice(0, 0, addTypeInLogs(newElement));
-                    console.log('Discovered appliance:\n' + jsonParseString(tmpLog.storages[0]) + '\n');
-                    if (tmpLog.storages.length > 1000) {
-                        tmpLog.storages.splice(1000, tmpLog.storages.length - 1000);
-                    }
+                    splicingLogStorages(tmpLog, newElement);
                 }
             }
         } else {
             tmp.storages.push(newElement);
-            tmpLog.storages.splice(0, 0, addTypeInLogs(newElement));
-            console.log('Discovered appliance:\n' + jsonParseString(tmpLog.storages[0]) + '\n');
-            if (tmpLog.storages.length > 1000) {
-                tmpLog.storages.splice(1000, tmpLog.storages.length - 1000);
-            }
+            splicingLogStorages(tmpLog, newElement);
         }
         storages = jsonParseString(tmp);
         detectionLog = jsonParseString(tmpLog);
@@ -263,7 +255,7 @@ function appOnDown(service) {
     detectionLog = jsonParseString(tmpLog);
     try {
         win.webContents.send('ping', storages, detectionLog);
-        win.webContents.send("update-appliance-list", namearr[1]); // TODO: Check if name is unique
+        win.webContents.send("update-appliance-list", 'delete', namearr[1]);
     }
     catch (err) {
     }

--- a/src/main.js
+++ b/src/main.js
@@ -233,7 +233,7 @@ function appOnUp(service) {
         // Send data to the UI part
         try {
             win.webContents.send('ping', storages, detectionLog);
-            win.webContents.send("update-appliance-list");
+            win.webContents.send("update-appliance-list", 'add');
         }
         catch (err) {
         }
@@ -263,7 +263,7 @@ function appOnDown(service) {
     detectionLog = jsonParseString(tmpLog);
     try {
         win.webContents.send('ping', storages, detectionLog);
-        win.webContents.send("update-appliance-list");
+        win.webContents.send("update-appliance-list", namearr[1]); // TODO: Check if name is unique
     }
     catch (err) {
     }

--- a/src/main.js
+++ b/src/main.js
@@ -233,6 +233,7 @@ function appOnUp(service) {
         // Send data to the UI part
         try {
             win.webContents.send('ping', storages, detectionLog);
+            win.webContents.send("update-appliance-list");
         }
         catch (err) {
         }
@@ -262,6 +263,7 @@ function appOnDown(service) {
     detectionLog = jsonParseString(tmpLog);
     try {
         win.webContents.send('ping', storages, detectionLog);
+        win.webContents.send("update-appliance-list");
     }
     catch (err) {
     }

--- a/src/main.js
+++ b/src/main.js
@@ -131,9 +131,9 @@ function appOnUp(service) {
 
     // New discovered system name parsing
 
-// Service format should be (underscore delimited only):
-// PSA|PSC_<SOMENAME>_<code-version>_<system-type>_<system-model>_<HW type>_Unified|Block_<system-state>
-//    0         1           2              3              4           5           6             7
+    // Service format should be (underscore delimited only):
+    // PSA|PSC_<SOMENAME>_<code-version>_<system-type>_<system-model>_<HW type>_Unified|Block_<system-state>
+    //    0         1           2              3              4           5           6             7
 
     const serviceNames = service.name.split('_');
     if (serviceNames[0] === 'PSA' || serviceNames[0] === 'PSC') {
@@ -161,15 +161,15 @@ function appOnUp(service) {
         //System model
         newElement.model = getModelByCode(serviceNames[4], newElement.type);
 
-        //System state
-        //  "Unconfigured", 0                 // system in factory state
-        //  "Unconfigured_Faulted", 1       // Hardware is in faulted state
-        //  "Configuring", 2                   // In the midst of being configured or unconfigured
-        //  "Configured", 3                     // system is configured
-        //  "Expanding", 4                       // System is adding a new appliance
-        //  "Removing", 5                         // System is removing an appliance
-        //  "Clustering_Failed", 6       // system in a bad state
-        //  "Unknown", 99                          // unknown state
+        // System state
+        //  "Unconfigured", 0                system in factory state
+        //  "Unconfigured_Faulted", 1        Hardware is in faulted state
+        //  "Configuring", 2                 In the midst of being configured or unconfigured
+        //  "Configured", 3                  system is configured
+        //  "Expanding", 4                   System is adding a new appliance
+        //  "Removing", 5                    System is removing an appliance
+        //  "Clustering_Failed", 6           system in a bad state
+        //  "Unknown", 99                    unknown state
 
         if (serviceNames[7] === '0' || serviceNames[7] === '1') {
             newElement.state = 'unconfigured';


### PR DESCRIPTION
This PR adds capability of detecting new appliances and inserting them into a table on Appliance Page without any user intervention (like clicking on 're-scan' button).

This may be troubling: from now on selected appliances and cluster are detected by name (not by id). The order of appliances is changeable now, so I thought that detect selection by unique key will be better than recalculate ids. And AFAIU name of appliance/cluster is an unique field (line 199 in main.js say so).  