### PR TITLE
Implement Discovery Utility support for multi appliance PSX clusters

### DIFF
--- a/src/app/components/Appliance.js
+++ b/src/app/components/Appliance.js
@@ -64,7 +64,7 @@ class Appliance extends Component {
         let {appliance, showSettingsMenu, itemClick, selectTypeCheckbox} = this.props;
         let applianceName = appliance.name;
         let applianceModel = appliance.model;
-        let applianceFailedClass = appliance.failed === "true" ? "app-failed-true" : "app-failed-false";
+        let applianceFailedClass = appliance.failed ? "app-failed-true" : "app-failed-false";
 
         return (
             <div className={this.getClassNames()} onClick={this.props.onClick}>
@@ -82,7 +82,14 @@ class Appliance extends Component {
 
                 <p className="app-name">{applianceName}</p>
                 <p className="app-model">{applianceModel}</p>
-                <img src="./images/warning.svg" width="25" height="25" id="Appliance_warningImage" className={applianceFailedClass} alt="warning" />
+                <img
+                    src="./images/warning.svg"
+                    width="25"
+                    height="25"
+                    id="Appliance_warningImage"
+                    className={applianceFailedClass}
+                    alt="warning"
+                />
 
                 {showSettingsMenu ? (
                     <div className="custom-dropdown dropleft">

--- a/src/app/containers/AppliancesPage.js
+++ b/src/app/containers/AppliancesPage.js
@@ -265,8 +265,8 @@ class AppliancesPage extends Component {
 
         if (appliances) {
             //filter appliances to configured and unconfigured
-            let configured = appliances.filter(appliance => appliance.cluster === "true");
-            let unconfigured = appliances.filter(appliance => appliance.cluster === "false");
+            let configured = appliances.filter(appliance => appliance.cluster);
+            let unconfigured = appliances.filter(appliance => !appliance.cluster);
 
             //count pages in pagination
             let countConfiguredPages = Math.ceil(configured.length / Constants.APPLIANCE_PAGE.MAX_APPLIANCES_ON_PAGE);
@@ -320,19 +320,19 @@ class AppliancesPage extends Component {
 
             if (countSelectedAppliances > 1) {
                 if (pageStateUnconfigured) {
-                    let firstType = unconfigured.find(appliance => appliance.name === selectedNames[0]).type;
+                    const firstAppliance = unconfigured.find(appliance => appliance.name === selectedNames[0]);
 
                     //check that appliances have same types and that they are not HCI
                     for (let i = 1; i < countSelectedAppliances; i++) {
-                        let nextType = unconfigured.find(appliance => appliance.name === selectedNames[i]).type;
+                        const nextAppliance = unconfigured.find(appliance => appliance.name === selectedNames[i]);
 
-                        if (nextType !== firstType) {
+                        if (nextAppliance.type !== firstAppliance.type) {
                             isAvailablePopupButton = false;
                             showTooltipMessage = true;
                             tooltipMessage = t.MIXED_CLUSTER_WARNING;
                             break;
                         }
-                        if (nextType === "HCI") {
+                        if (nextAppliance.type === "HCI" && (nextAppliance.compatibility < 10 || firstAppliance.compatibility < 10)) {
                             isAvailablePopupButton = false;
                             showTooltipMessage = true;
                             tooltipMessage = t.MULTI_HCI_CLUSTER_WARNING;

--- a/src/app/locales/translation.js
+++ b/src/app/locales/translation.js
@@ -48,12 +48,7 @@ let translation = new LocalizedStrings({
             "T and " +
             productName +
             "X appliances. Creating a cluster with appliances with different configurations is not supported in this release.",
-        MULTI_HCI_CLUSTER_WARNING:
-            "Your selection has more than one " +
-            productName +
-            "X appliance. In this release, you can only configure a cluster with one " +
-            productName +
-            "X appliance.",
+        MULTI_HCI_CLUSTER_WARNING: "Some of the selected " + productName + "X appliances do not support multi appliance clusters",
         MAX_APPLIANCES_IN_CLUSTER: "Your selection would result in too many appliances in the cluster",
         GO_TO_CLUSTER: "Launch " + productName + " Manager",
         ADD_TO_EXISTING: "Add to existing cluster",

--- a/src/demo/demo_data.json
+++ b/src/demo/demo_data.json
@@ -5,9 +5,10 @@
       "name": "FNM00103198723",
       "state": "unconfigured",
       "type": "HCI",
+      "compatibility": 1,
       "model": "PowerStore 1000X",
-      "cluster": "false",
-      "failed": "false"
+      "cluster": false,
+      "failed": false
     },
     {
       "link": "https://10.248.178.162",
@@ -15,8 +16,9 @@
       "state": "configured",
       "model": "PowerStore 1000T",
       "type": "BM",
-      "cluster": "true",
-      "failed": "false"
+      "compatibility": 1,
+      "cluster": true,
+      "failed": false
 
     },
     {
@@ -25,8 +27,9 @@
       "state": "service state",
       "model": "PowerStore 1000T",
       "type": "BM",
-      "cluster": "true",
-      "failed": "true"
+      "compatibility": 1,
+      "cluster": true,
+      "failed": true
 
     },
     {
@@ -35,8 +38,9 @@
       "state": "unconfigured",
       "model": "PowerStore 1000X",
       "type": "HCI",
-      "cluster": "false",
-      "failed": "true"
+      "compatibility": 1,
+      "cluster": false,
+      "failed": true
     },
     {
       "link": "http://192.168.6.47:8080",
@@ -44,8 +48,9 @@
       "state": "configured",
       "model": "PowerStore 1000T",
       "type": "BM",
-      "cluster": "true",
-      "failed": "false"
+      "compatibility": 1,
+      "cluster": true,
+      "failed": false
     },
     {
       "link": "http://192.168.3.45:8080",
@@ -53,8 +58,9 @@
       "state": "configured",
       "model": "PowerStore 1000T",
       "type": "BM",
-      "cluster": "true",
-      "failed": "false"
+      "compatibility": 1,
+      "cluster": true,
+      "failed": false
     },
     {
       "link": "http://192.168.1.34:8080",
@@ -62,8 +68,9 @@
       "state": "configured",
       "model": "PowerStore 3000X",
       "type": "HCI",
-      "cluster": "true",
-      "failed": "false"
+      "compatibility": 1,
+      "cluster": true,
+      "failed": false
     },
     {
       "link": "http://192.168.8.14:8080",
@@ -71,8 +78,9 @@
       "state": "unconfigured",
       "model": "PowerStore 9000X",
       "type": "HCI",
-      "cluster": "false",
-      "failed": "false"
+      "compatibility": 10,
+      "cluster": false,
+      "failed": false
     },
     {
       "link": "http://192.168.8.144:8080",
@@ -80,8 +88,9 @@
       "state": "service state",
       "model": "PowerStore 1000T",
       "type": "BM",
-      "cluster": "true",
-      "failed": "false"
+      "compatibility": 1,
+      "cluster": true,
+      "failed": false
     },
     {
       "link": "http://192.168.1.34:8080",
@@ -89,8 +98,9 @@
       "state": "unconfigured",
       "model": "PowerStore 1000X",
       "type": "HCI",
-      "cluster": "false",
-      "failed": "false"
+      "compatibility": 10,
+      "cluster": false,
+      "failed": false
     },
     {
       "link": "http://192.168.2.58:8080",
@@ -98,8 +108,9 @@
       "state": "unconfigured",
       "model": "PowerStore 1000T",
       "type": "BM",
-      "cluster": "false",
-      "failed": "false"
+      "compatibility": 1,
+      "cluster": false,
+      "failed": false
     },
     {
       "link": "http://192.168.2.58:8080",
@@ -107,71 +118,79 @@
       "state": "unconfigured",
       "model": "PowerStore 1000X",
       "type": "HCI",
-      "cluster": "false",
-      "failed": "false"
+      "compatibility": 1,
+      "cluster": false,
+      "failed": false
     },
     {
       "link": "http://192.168.2.58:8080",
       "name": "FNM003456009764",
       "state": "unconfigured",
       "type": "BM",
+      "compatibility": 1,
       "model": "PowerStore 1000T",
-      "cluster": "false",
-      "failed": "false"
+      "cluster": false,
+      "failed": false
     },
     {
       "link": "http://192.168.2.58:8080",
       "name": "FNM003456009765",
       "state": "unconfigured",
       "type": "HCI",
+      "compatibility": 1,
       "model": "PowerStore 1000X",
-      "cluster": "false",
-      "failed": "false"
+      "cluster": false,
+      "failed": false
     },
     {
       "link": "http://192.168.2.58:8080",
       "name": "FNM003456444754",
       "state": "unconfigured",
       "type": "BM",
+      "compatibility": 1,
       "model": "PowerStore 1000T",
-      "cluster": "false",
-      "failed": "false"
+      "cluster": false,
+      "failed": false
     },
     {
       "link": "http://192.168.2.58:8080",
       "name": "FNM003432402309744",
       "state": "unconfigured",
       "type": "HCI",
+      "compatibility": 1,
       "model": "PowerStore 1000X",
-      "cluster": "false",
-      "failed": "false"
+      "cluster": false,
+      "failed": false
     },
     {
       "link": "http://192.168.2.58:8080",
       "name": "FNM0044949009767",
       "state": "unconfigured",
       "type": "BM",
+      "compatibility": 1,
       "model": "PowerStore 1000T",
-      "cluster": "false",
-      "failed": "false"
+      "cluster": false,
+      "failed": false
     },
     {
       "link": "http://192.168.2.58:8080",
       "name": "FNM0033475097866",
       "state": "unconfigured",
       "type": "HCI",
+      "compatibility": 1,
       "model": "PowerStore 1000X",
-      "cluster": "false",
-      "failed": "false"
+      "cluster": false,
+      "failed": false
     },
     {
       "link": "http://192.168.2.58:8080",
       "name": "FNM0034560045123",
       "state": "unconfigured",
       "type": "BM",
+      "compatibility": 1,
       "model": "PowerStore 1000T",
-      "cluster": "false",
-      "failed": "false"
+      "cluster": false,
+      "failed": false
     }
   ]
 }

--- a/src/test/TestData.json
+++ b/src/test/TestData.json
@@ -6,9 +6,10 @@
         "name": "FNM00103198723",
         "state": "unconfigured",
         "type": "HCI",
+        "compatibility": 1,
         "model": "PowerStore 1000X",
-        "cluster": "false",
-        "failed": "false"
+        "cluster": false,
+        "failed": false
       },
       {
         "id": 1,
@@ -17,8 +18,9 @@
         "state": "unconfigured",
         "model": "PowerStore 1000X",
         "type": "HCI",
-        "cluster": "false",
-        "failed": "true"
+        "compatibility": 1,
+        "cluster": false,
+        "failed": true
       },
       {
         "id": 2,
@@ -27,8 +29,9 @@
         "state": "unconfigured",
         "model": "PowerStore 1000X",
         "type": "HCI",
-        "cluster": "false",
-        "failed": "true"
+        "compatibility": 1,
+        "cluster": false,
+        "failed": true
       },
       {
         "id": 3,
@@ -37,8 +40,9 @@
         "state": "unconfigured",
         "model": "PowerStore 1000",
         "type": "BM",
-        "cluster": "false",
-        "failed": "false"
+        "compatibility": 1,
+        "cluster": false,
+        "failed": false
       },
       {
         "id": 4,
@@ -47,8 +51,9 @@
         "state": "unconfigured",
         "model": "PowerStore 1000",
         "type": "BM",
-        "cluster": "false",
-        "failed": "false"
+        "compatibility": 1,
+        "cluster": false,
+        "failed": false
       },
       {
         "id": 5,
@@ -57,8 +62,9 @@
         "state": "unconfigured",
         "model": "PowerStore 1000",
         "type": "BM",
-        "cluster": "false",
-        "failed": "false"
+        "compatibility": 1,
+        "cluster": false,
+        "failed": false
       },
       {
         "id": 6,
@@ -67,8 +73,9 @@
         "state": "configured",
         "model": "PowerStore 1000",
         "type": "BM",
-        "cluster": "true",
-        "failed": "false"
+        "compatibility": 1,
+        "cluster": true,
+        "failed": false
       },
       {
         "id": 7,
@@ -77,8 +84,9 @@
         "state": "configured",
         "model": "PowerStore 3000X",
         "type": "HCI",
-        "cluster": "true",
-        "failed": "false"
+        "compatibility": 1,
+        "cluster": true,
+        "failed": false
       }
     ]
   }

--- a/src/test/components/ApplianceTest.js
+++ b/src/test/components/ApplianceTest.js
@@ -5,30 +5,33 @@ const DEMO_APPLIANCE = {
     link: "http://192.168.0.100:8080",
     name: "FNM00103198723",
     state: "unconfigured",
+    compatibility: 1,
     type: "HCI",
     model: "PowerStore 1000X",
-    cluster: "false",
-    failed: "false"
+    cluster: false,
+    failed: false
 };
 
 const DEMO_APPLIANCE_WITH_WARNING = {
     link: "http://192.168.0.100:8080",
     name: "FNM00103198723",
     state: "unconfigured",
+    compatibility: 1,
     type: "HCI",
     model: "PowerStore 1000X",
-    cluster: "false",
-    failed: "true"
+    cluster: false,
+    failed: true
 };
 
 const DEMO_CLUSTER = {
     link: "https://10.248.178.162",
     name: "ClusterSample",
     state: "configured",
+    compatibility: 1,
     model: "PowerStore 1000",
     type: "BM",
-    cluster: "true",
-    failed: "false"
+    cluster: true,
+    failed: false
 };
 
 describe("Appliance component tests", () => {

--- a/src/test/containers/AppliancePageTest.js
+++ b/src/test/containers/AppliancePageTest.js
@@ -76,7 +76,7 @@ describe("AppliancePage container tests", () => {
         const firstAppliance = page.find(Appliance).at(0);
         const secondAppliance = page.find(Appliance).at(1);
 
-        const appliances = testData.storages.filter(appliance => appliance.cluster === "false");
+        const appliances = testData.storages.filter(appliance => !appliance.cluster);
 
         expect(page.state("selectedNames")).to.deep.equal([]);
 
@@ -108,7 +108,7 @@ describe("AppliancePage container tests", () => {
         const firstCluster = page.find(Appliance).at(0);
         const secondCluster = page.find(Appliance).at(1);
 
-        const clusters = testData.storages.filter(appliance => appliance.cluster === "true");
+        const clusters = testData.storages.filter(appliance => appliance.cluster);
 
         expect(page.state("selectedNames")).to.deep.equal([]);
 

--- a/testcafe/helpers/localStorage.js
+++ b/testcafe/helpers/localStorage.js
@@ -15,6 +15,6 @@ const getLocalStorageItem = ClientFunction(prop => {
 export async function parseLocalStorage(isClusterList) {
     const localStorage = JSON.parse(await getLocalStorageItem("message"));
     return localStorage.storages.filter(appliance => {
-        return appliance.cluster === `${isClusterList}`;
+        return appliance.cluster === isClusterList;
     });
 }

--- a/testcafe/helpers/publishing.js
+++ b/testcafe/helpers/publishing.js
@@ -1,0 +1,45 @@
+import Constants from "../../src/app/constants/Constants";
+const exec = require("child_process").exec;
+
+/**
+ * Script for publishing new appliances
+ * @param {string[]} applianceList
+ * @returns {ChildProcess[]}
+ */
+export async function execPublishProcess(applianceList) {
+    const platform = process.platform;
+
+    const childProcesses = [];
+
+    // Execute publishing script
+    if (platform === Constants.PLATFORM_TYPES.WIN) {
+        applianceList.forEach(appliance => {
+            const process = exec(`dns-sd -R ${appliance} _http._tcp . 3000`);
+            childProcesses.push(process);
+        });
+    } else if (platform === Constants.PLATFORM_TYPES.LINUX) {
+        applianceList.forEach(appliance => {
+            const process = exec(`avahi-publish-service ${appliance} _http._tcp 3000`);
+            childProcesses.push(process);
+        });
+    } else {
+        console.log("This test is not runnable in your OS");
+    }
+
+    return childProcesses;
+}
+
+export async function killPublishProcess(childProcesses) {
+    const platform = process.platform;
+
+    // Kill the child process
+    if (platform === Constants.PLATFORM_TYPES.WIN) {
+        childProcesses.map(process => {
+            exec(`taskkill /pid ${process.pid} /f /t`);
+        });
+    } else if (platform === Constants.PLATFORM_TYPES.LINUX) {
+        childProcesses.map(process => {
+            process.kill();
+        });
+    }
+}


### PR DESCRIPTION
This PR:
- Adds support for multi appliance PSX clusters
- Adds new TestCafe tests
- Fixes the usage of booleans as a strings ([ref to review comment](https://github.com/VictoriaCherkalova/connection-utility-tool/pull/32#discussion_r382511157))
- Improves main.js a little bit

---
Tests: 
- [x] Prettier check
- [x] Unit tests
- [x] TestCafe tests